### PR TITLE
Cleanup unused/removed generated files on directory

### DIFF
--- a/Sources/Lingua/Domain/UseCases/Localization/FileCleanupStrategy.swift
+++ b/Sources/Lingua/Domain/UseCases/Localization/FileCleanupStrategy.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol FileCleanupStrategy {
+  func removeFiles(using directoryOperator: DirectoryOperable, in folder: URL) throws
+}

--- a/Sources/Lingua/Infrastructure/DirectoryOperations/DirectoryOperable.swift
+++ b/Sources/Lingua/Infrastructure/DirectoryOperations/DirectoryOperable.swift
@@ -3,6 +3,7 @@ import Foundation
 protocol DirectoryOperable {
   func createDirectory(named: String, in outputDirectory: String) throws -> URL
   func removeFiles(withPrefix prefix: String, in directory: URL) throws
+  func removeAllFiles(in directory: URL) throws
 }
 
 final class DirectoryOperator: DirectoryOperable {
@@ -29,6 +30,20 @@ final class DirectoryOperator: DirectoryOperable {
     let fileURLs = try fileManager.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
     
     for fileURL in fileURLs where fileURL.lastPathComponent.hasPrefix(prefix) {
+      do {
+        try fileManager.removeItem(at: fileURL)
+      } catch {
+        throw DirectoryOperationError.removeItemFailed
+      }
+    }
+  }
+  
+  func removeAllFiles(in directory: URL) throws {
+    let fileManager = fileManagerProvider.manager
+    
+    let fileURLs = try fileManager.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+    
+    for fileURL in fileURLs {
       do {
         try fileManager.removeItem(at: fileURL)
       } catch {

--- a/Sources/Lingua/Infrastructure/LocalizationGenerator/Factory/FileCleanupFactory.swift
+++ b/Sources/Lingua/Infrastructure/LocalizationGenerator/Factory/FileCleanupFactory.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+struct FileCleanupFactory {
+  static func make(for localizationPlatform: LocalizationPlatform) -> FileCleanupStrategy {
+    switch localizationPlatform {
+    case .ios:
+      return IOSFileCleanupStrategy()
+    case .android:
+      return AndroidFileCleanupStrategy()
+    }
+  }
+}

--- a/Sources/Lingua/Infrastructure/LocalizationGenerator/Factory/LocalizedFilesGeneratorFactory.swift
+++ b/Sources/Lingua/Infrastructure/LocalizationGenerator/Factory/LocalizedFilesGeneratorFactory.swift
@@ -14,9 +14,11 @@ struct LocalizedFilesGeneratorFactory {
                                                          fileNameGenerator: fileNameGenerator)
     
     let directoryManager = DirectoryOperator.makeDefault()
+    let fileCleanupStrategy = FileCleanupFactory.make(for: localizationPlatform)
     let generator = LocalizedFilesGenerator(directoryOperator: directoryManager,
                                             filesGenerator: filesGenerator,
-                                            localizationPlatform: localizationPlatform)
+                                            localizationPlatform: localizationPlatform,
+                                            fileCleanup: fileCleanupStrategy)
     
     return generator
   }

--- a/Sources/Lingua/Infrastructure/LocalizationGenerator/Generator/LocalizedFilesGenerator.swift
+++ b/Sources/Lingua/Infrastructure/LocalizationGenerator/Generator/LocalizedFilesGenerator.swift
@@ -4,13 +4,16 @@ final class LocalizedFilesGenerator {
   private let directoryOperator: DirectoryOperable
   private let filesGenerator: PlatformFilesGenerating
   private let localizationPlatform: LocalizationPlatform
+  private let fileCleanup: FileCleanupStrategy
   
   init(directoryOperator: DirectoryOperable,
        filesGenerator: PlatformFilesGenerating,
-       localizationPlatform: LocalizationPlatform) {
+       localizationPlatform: LocalizationPlatform,
+       fileCleanup: FileCleanupStrategy) {
     self.directoryOperator = directoryOperator
     self.filesGenerator = filesGenerator
     self.localizationPlatform = localizationPlatform
+    self.fileCleanup = fileCleanup
   }
 }
 
@@ -19,7 +22,7 @@ extension LocalizedFilesGenerator: LocalizedFilesGenerating {
     let languageCode = sheet.languageCode
     let folderName = localizationPlatform.folderName(for: languageCode)
     let outputFolder = try directoryOperator.createDirectory(named: folderName, in: config.outputDirectory)
-    try directoryOperator.removeFiles(withPrefix: .packageName, in: outputFolder)
+    try fileCleanup.removeFiles(using: directoryOperator, in: outputFolder)
     
     let sections = Dictionary(grouping: sheet.entries, by: { $0.section })
     

--- a/Sources/Lingua/Infrastructure/LocalizationGenerator/Output/Android/AndroidFileCleanupStrategy.swift
+++ b/Sources/Lingua/Infrastructure/LocalizationGenerator/Output/Android/AndroidFileCleanupStrategy.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct AndroidFileCleanupStrategy: FileCleanupStrategy {
+  func removeFiles(using directoryOperator: DirectoryOperable, in folder: URL) throws {
+    try directoryOperator.removeFiles(withPrefix: .packageName, in: folder)
+  }
+}

--- a/Sources/Lingua/Infrastructure/LocalizationGenerator/Output/iOS/IOSFileCleanupStrategy.swift
+++ b/Sources/Lingua/Infrastructure/LocalizationGenerator/Output/iOS/IOSFileCleanupStrategy.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct IOSFileCleanupStrategy: FileCleanupStrategy {
+  func removeFiles(using directoryOperator: DirectoryOperable, in folder: URL) throws {
+    try directoryOperator.removeAllFiles(in: folder)
+  }
+}

--- a/Tests/LinguaTests/Infrastructure/LocalizationGenerator/Generator/LocalizedFilesGeneratorTests.swift
+++ b/Tests/LinguaTests/Infrastructure/LocalizationGenerator/Generator/LocalizedFilesGeneratorTests.swift
@@ -2,15 +2,16 @@ import XCTest
 @testable import Lingua
 
 final class LocalizedFilesGeneratorTests: XCTestCase {
-  func test_generate_callsExpectedMethods() throws {
+  func test_generate_callsExpectedMethods_forAndroidPlatform() throws {
     let directoryOperator = MockDirectoryOperator()
     let filesGenerator = MockPlatformFilesGenerator()
-    let localizationPlatform = LocalizationPlatform.ios
+    let localizationPlatform = LocalizationPlatform.android
     
     let sut = LocalizedFilesGenerator(
       directoryOperator: directoryOperator,
       filesGenerator: filesGenerator,
-      localizationPlatform: localizationPlatform
+      localizationPlatform: localizationPlatform,
+      fileCleanup: FileCleanupFactory.make(for: localizationPlatform)
     )
     
     let sheet = LocalizationSheet(language: "en", entries: [LocalizationEntry.create(plural: true)])
@@ -24,5 +25,30 @@ final class LocalizedFilesGeneratorTests: XCTestCase {
                    [.createDirectory(named: localizationPlatform.folderName(for: sheet.languageCode),
                                      directory: config.outputDirectory),
                     .removeFiles(prefix: "Lingua", directory: outputDirectoryURL)])
+  }
+  
+  func test_generate_callsExpectedMethods_forIOSPlatform() throws {
+    let directoryOperator = MockDirectoryOperator()
+    let filesGenerator = MockPlatformFilesGenerator()
+    let localizationPlatform = LocalizationPlatform.ios
+    
+    let sut = LocalizedFilesGenerator(
+      directoryOperator: directoryOperator,
+      filesGenerator: filesGenerator,
+      localizationPlatform: localizationPlatform,
+      fileCleanup: FileCleanupFactory.make(for: localizationPlatform)
+    )
+    
+    let sheet = LocalizationSheet(language: "en", entries: [LocalizationEntry.create(plural: true)])
+    let config = Config.Localization(apiKey: "key", sheetId: "id", outputDirectory: "path", localizedSwiftCode: .none)
+    let outputDirectoryURL = try XCTUnwrap(URL(string: config.outputDirectory))
+    directoryOperator.url = outputDirectoryURL
+    
+    try sut.generate(for: sheet, config: config)
+    
+    XCTAssertEqual(directoryOperator.messages,
+                   [.createDirectory(named: localizationPlatform.folderName(for: sheet.languageCode),
+                                     directory: config.outputDirectory),
+                    .removeAllFiles(directory: outputDirectoryURL)])
   }
 }

--- a/Tests/LinguaTests/Infrastructure/LocalizationGenerator/Generator/Mock/MockDirectoryOperator.swift
+++ b/Tests/LinguaTests/Infrastructure/LocalizationGenerator/Generator/Mock/MockDirectoryOperator.swift
@@ -5,6 +5,7 @@ class MockDirectoryOperator: DirectoryOperable {
   enum Message: Equatable {
     case createDirectory(named: String, directory: String)
     case removeFiles(prefix: String, directory: URL)
+    case removeAllFiles(directory: URL)
   }
   
   private(set) var messages = [Message]()
@@ -17,5 +18,9 @@ class MockDirectoryOperator: DirectoryOperable {
   
   func removeFiles(withPrefix prefix: String, in directory: URL) throws {
     messages.append(.removeFiles(prefix: prefix, directory: directory))
+  }
+  
+  func removeAllFiles(in directory: URL) throws {
+    messages.append(.removeAllFiles(directory: directory))
   }
 }

--- a/Tests/LinguaTests/Infrastructure/SwiftLocalizeGenerator/PlaceholderExtractor/PlaceholderExtractorTests.swift
+++ b/Tests/LinguaTests/Infrastructure/SwiftLocalizeGenerator/PlaceholderExtractor/PlaceholderExtractorTests.swift
@@ -19,7 +19,8 @@ final class PlaceholderExtractorTests: XCTestCase {
   }
   
   func testMultiplePlaceholdersExtraction() {
-    expect(testString: "Hello %@, you are %d years old and your average grade is %f.",
+    expect(sut: PlaceholderExtractor(strategy: NSRegularExpressionPlaceholderExtractor()),
+           testString: "Hello %@, you are %d years old and your average grade is %f.",
            expectedTypes: ["String", "Int", "Double"])
   }
   


### PR DESCRIPTION
- Since in iOS we have only localization files in a localization folder, the tool will remove all files and create the new ones from GoogleSheet
- Android uses the strategy with prefix for the files generated by the tool

Closes #102 