### PR TITLE
Fix/Menu bar tint icon

### DIFF
--- a/Lingua-App/Lingua/Lingua/Resources/Assets.xcassets/lingua_menu_bar_icon.imageset/Contents.json
+++ b/Lingua-App/Lingua/Lingua/Resources/Assets.xcassets/lingua_menu_bar_icon.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
The issue 
<img width="509" alt="Screenshot 2024-09-23 at 10 11 24" src="https://github.com/user-attachments/assets/e2a3672e-5d92-46cd-a2ae-b8f17647fca0">

The fix
<img width="445" alt="Screenshot 2024-09-23 at 10 06 19" src="https://github.com/user-attachments/assets/6766c242-2148-49e6-be93-9977075a0ac6">