### PR TITLE
Fix/Directory access errors

### DIFF
--- a/Lingua-App/Lingua/Lingua/Utils/Components/UI/ValidatingTextField.swift
+++ b/Lingua-App/Lingua/Lingua/Utils/Components/UI/ValidatingTextField.swift
@@ -37,8 +37,9 @@ struct ValidatingTextField: View {
     VStack(alignment: .leading, spacing: 5) {
       TextField(title, text: $localText)
         .disabled(isDisabled)
-        .cornerRadius(8)
         .focused($isFocused)
+        .frame(minHeight: 20)
+        .padding(.trailing)
         .onChange(of: isFocused) { focused in
           if !focused {
             validate()
@@ -50,6 +51,10 @@ struct ValidatingTextField: View {
           .foregroundColor(.red)
           .font(.caption)
       }
+    }
+    .contentShape(Rectangle())
+    .onTapGesture {
+      isFocused = true
     }
     .onAppear {
       isValid = validation.validate(text)

--- a/Sources/LinguaLib/Infrastructure/DirectoryOperations/DirectoryOperable.swift
+++ b/Sources/LinguaLib/Infrastructure/DirectoryOperations/DirectoryOperable.swift
@@ -27,6 +27,8 @@ public final class DirectoryOperator: DirectoryOperable {
     
     do {
       try fileManagerProvider.manager.createDirectory(at: outputFolder, withIntermediateDirectories: true, attributes: nil)
+    } catch let error as DirectoryOperationError {
+      throw error
     } catch {
       throw DirectoryOperationError.folderCreationFailed(error.localizedDescription)
     }
@@ -42,6 +44,8 @@ public final class DirectoryOperator: DirectoryOperable {
     for fileURL in fileURLs where fileURL.lastPathComponent.hasPrefix(prefix) {
       do {
         try fileManager.removeItem(at: fileURL)
+      } catch let error as DirectoryOperationError {
+        throw error
       } catch {
         throw DirectoryOperationError.removeItemFailed(error.localizedDescription)
       }

--- a/Sources/LinguaLib/Infrastructure/DirectoryOperations/DirectoryOperable.swift
+++ b/Sources/LinguaLib/Infrastructure/DirectoryOperations/DirectoryOperable.swift
@@ -14,13 +14,23 @@ public final class DirectoryOperator: DirectoryOperable {
   }
   
   public func createDirectory(named directoryName: String, in outputDirectory: String) throws -> URL {
-    let mainFolder = URL(fileURLWithPath: outputDirectory)
+    guard !directoryName.isEmpty else {
+      throw DirectoryOperationError.folderCreationFailed("Directory name is empty.")
+    }
+    
+    guard let decodedPath = outputDirectory.removingPercentEncoding else {
+      throw DirectoryOperationError.folderCreationFailed("Invalid output directory path.")
+    }
+    
+    let mainFolder = URL(fileURLWithPath: decodedPath)
     let outputFolder = mainFolder.appendingPathComponent(directoryName)
+    
     do {
       try fileManagerProvider.manager.createDirectory(at: outputFolder, withIntermediateDirectories: true, attributes: nil)
     } catch {
-      throw DirectoryOperationError.folderCreationFailed
+      throw DirectoryOperationError.folderCreationFailed(error.localizedDescription)
     }
+    
     return outputFolder
   }
   
@@ -33,7 +43,7 @@ public final class DirectoryOperator: DirectoryOperable {
       do {
         try fileManager.removeItem(at: fileURL)
       } catch {
-        throw DirectoryOperationError.removeItemFailed
+        throw DirectoryOperationError.removeItemFailed(error.localizedDescription)
       }
     }
   }
@@ -47,7 +57,7 @@ public final class DirectoryOperator: DirectoryOperable {
       do {
         try fileManager.removeItem(at: fileURL)
       } catch {
-        throw DirectoryOperationError.removeItemFailed
+        throw DirectoryOperationError.removeItemFailed(error.localizedDescription)
       }
     }
   }

--- a/Sources/LinguaLib/Infrastructure/DirectoryOperations/DirectoryOperationError.swift
+++ b/Sources/LinguaLib/Infrastructure/DirectoryOperations/DirectoryOperationError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum DirectoryOperationError: LocalizedError {
+public enum DirectoryOperationError: LocalizedError, Equatable {
   case folderCreationFailed(String)
   case removeItemFailed(String)
   

--- a/Sources/LinguaLib/Infrastructure/DirectoryOperations/DirectoryOperationError.swift
+++ b/Sources/LinguaLib/Infrastructure/DirectoryOperations/DirectoryOperationError.swift
@@ -1,15 +1,15 @@
 import Foundation
 
 public enum DirectoryOperationError: LocalizedError {
-  case folderCreationFailed
-  case removeItemFailed
+  case folderCreationFailed(String)
+  case removeItemFailed(String)
   
   public var errorDescription: String? {
     switch self {
-    case .folderCreationFailed:
-      return "Failed to create the folder in given directory"
-    case .removeItemFailed:
-      return "Failed to remove item in this folder"
+    case .folderCreationFailed(let error):
+      return "Failed to create the folder in given directory.\nReason: \(error)"
+    case .removeItemFailed(let error):
+      return "Failed to remove item in this folder.\nReason: \(error)"
     }
   }
 }

--- a/Sources/LinguaLib/Infrastructure/LocalizationGenerator/Generator/PlatformLocalizationGenerator.swift
+++ b/Sources/LinguaLib/Infrastructure/LocalizationGenerator/Generator/PlatformLocalizationGenerator.swift
@@ -12,11 +12,7 @@ final class PlatformLocalizationGenerator: PlatformLocalizationGenerating {
   
   func generateLocalizationFiles(data: [LocalizationSheet], config: Config.Localization) throws {
     try data.forEach { data in
-      do {
-        try localizedFileGenerator.generate(for: data, config: config)
-      } catch {
-        throw error
-      }
+      try localizedFileGenerator.generate(for: data, config: config)
     }
   }
 }

--- a/Sources/LinguaLib/Infrastructure/LocalizationGenerator/Generator/PlatformLocalizationGenerator.swift
+++ b/Sources/LinguaLib/Infrastructure/LocalizationGenerator/Generator/PlatformLocalizationGenerator.swift
@@ -11,8 +11,12 @@ final class PlatformLocalizationGenerator: PlatformLocalizationGenerating {
   }
   
   func generateLocalizationFiles(data: [LocalizationSheet], config: Config.Localization) throws {
-    data.forEach { data in
-      try? localizedFileGenerator.generate(for: data, config: config)
+    try data.forEach { data in
+      do {
+        try localizedFileGenerator.generate(for: data, config: config)
+      } catch {
+        throw error
+      }
     }
   }
 }

--- a/Tests/LinguaTests/Application/Processor/LocalizationProcessorTests.swift
+++ b/Tests/LinguaTests/Application/Processor/LocalizationProcessorTests.swift
@@ -35,7 +35,7 @@ final class LocalizationProcessorTests: XCTestCase {
   }
   
   func test_process_throwsErrorWhenModuleLocalizationFails() async throws {
-    let localizationModule = MockLocalizationModule(shouldThrow: true)
+    let localizationModule = MockLocalizationModule(shouldThrow: "Error_message")
     let (sut, actors) = makeSUT(localizationModule: localizationModule)
     let tempDirectoryURL = try createTemporaryDirectoryURL()
     let configPath = try createTemporaryConfigFile(data: createConfigData(in: tempDirectoryURL), tempDirectoryURL: tempDirectoryURL)
@@ -47,7 +47,7 @@ final class LocalizationProcessorTests: XCTestCase {
       XCTAssertEqual(actors.logger.messages, [.message(message: "Loading configuration file...", level: .info),
                                               .message(message: "Initializing localization module...", level: .info),
                                               .message(message: "Starting localization...", level: .info),
-                                              .message(message: DirectoryOperationError.folderCreationFailed.localizedDescription, level: .error)])
+                                              .message(message: DirectoryOperationError.folderCreationFailed("Error_message").localizedDescription, level: .error)])
       XCTAssertEqual(actors.mockLocalizationModule.messages, [])
     }
   }
@@ -85,7 +85,7 @@ private extension LocalizationProcessorTests {
     let mockLocalizationModule: MockLocalizationModule
   }
   
-  func makeSUT(localizationModule: MockLocalizationModule = MockLocalizationModule(),
+  func makeSUT(localizationModule: MockLocalizationModule = MockLocalizationModule(shouldThrow: .none),
                configFileGenerator: ConfigInitialFileGenerating = ConfigInitialFileGenerator.make()) -> (sut: LocalizationProcessor, actors: Actors) {
     let argumentParser = CommandLineParser()
     let logger = MockLogger()

--- a/Tests/LinguaTests/Application/Processor/LocalizationProcessorTests.swift
+++ b/Tests/LinguaTests/Application/Processor/LocalizationProcessorTests.swift
@@ -35,7 +35,7 @@ final class LocalizationProcessorTests: XCTestCase {
   }
   
   func test_process_throwsErrorWhenModuleLocalizationFails() async throws {
-    let localizationModule = MockLocalizationModule(shouldThrow: "Error_message")
+    let localizationModule = MockLocalizationModule(errorMessage: "Error_message")
     let (sut, actors) = makeSUT(localizationModule: localizationModule)
     let tempDirectoryURL = try createTemporaryDirectoryURL()
     let configPath = try createTemporaryConfigFile(data: createConfigData(in: tempDirectoryURL), tempDirectoryURL: tempDirectoryURL)
@@ -85,7 +85,7 @@ private extension LocalizationProcessorTests {
     let mockLocalizationModule: MockLocalizationModule
   }
   
-  func makeSUT(localizationModule: MockLocalizationModule = MockLocalizationModule(shouldThrow: .none),
+  func makeSUT(localizationModule: MockLocalizationModule = MockLocalizationModule(errorMessage: .none),
                configFileGenerator: ConfigInitialFileGenerating = ConfigInitialFileGenerator.make()) -> (sut: LocalizationProcessor, actors: Actors) {
     let argumentParser = CommandLineParser()
     let logger = MockLogger()

--- a/Tests/LinguaTests/Application/Processor/Mock/MockLocalizationModule.swift
+++ b/Tests/LinguaTests/Application/Processor/Mock/MockLocalizationModule.swift
@@ -6,15 +6,15 @@ final class MockLocalizationModule: ModuleLocalizing {
     case localize(LocalizationPlatform)
   }
   private(set) var messages = [Message]()
-  private let shouldThrow: Bool
+  private let shouldThrow: String?
   
-  init(shouldThrow: Bool = false) {
+  init(shouldThrow: String?) {
     self.shouldThrow = shouldThrow
   }
   
   func localize(for platform: LocalizationPlatform) async throws {
-    if shouldThrow {
-      throw DirectoryOperationError.folderCreationFailed
+    if let shouldThrow {
+      throw DirectoryOperationError.folderCreationFailed(shouldThrow)
     }
     messages.append(.localize(platform))
   }

--- a/Tests/LinguaTests/Application/Processor/Mock/MockLocalizationModule.swift
+++ b/Tests/LinguaTests/Application/Processor/Mock/MockLocalizationModule.swift
@@ -6,15 +6,15 @@ final class MockLocalizationModule: ModuleLocalizing {
     case localize(LocalizationPlatform)
   }
   private(set) var messages = [Message]()
-  private let shouldThrow: String?
+  private let errorMessage: String?
   
-  init(shouldThrow: String?) {
-    self.shouldThrow = shouldThrow
+  init(errorMessage: String?) {
+    self.errorMessage = errorMessage
   }
   
   func localize(for platform: LocalizationPlatform) async throws {
-    if let shouldThrow {
-      throw DirectoryOperationError.folderCreationFailed(shouldThrow)
+    if let errorMessage {
+      throw DirectoryOperationError.folderCreationFailed(errorMessage)
     }
     messages.append(.localize(platform))
   }

--- a/Tests/LinguaTests/Infrastructure/DirectoryOperations/DirectoryOperatorTests.swift
+++ b/Tests/LinguaTests/Infrastructure/DirectoryOperations/DirectoryOperatorTests.swift
@@ -13,13 +13,25 @@ final class DirectoryOperatorTests: XCTestCase {
   
   func test_createDirectory_throwsError_onFailure() {
     let errorFileManager = MockFileManager()
-    errorFileManager.shouldThrowErrorOnCreateDirectory = true
+    errorFileManager.shouldThrowErrorOnCreateDirectory = "Create_failed"
     let sut = makeSUT(fileManager: errorFileManager)
     let outputDirectory = NSTemporaryDirectory()
     let directoryName = "TestDirectory"
     
     XCTAssertThrowsError(try sut.createDirectory(named: directoryName, in: outputDirectory)) { error in
-      XCTAssertEqual(error as? DirectoryOperationError, DirectoryOperationError.folderCreationFailed)
+      XCTAssertEqual((error as? DirectoryOperationError), DirectoryOperationError.folderCreationFailed("Create_failed"))
+    }
+  }
+  
+  func test_createDirectory_throwsError_onEmptyDirectory() {
+    let errorFileManager = MockFileManager()
+    errorFileManager.shouldThrowErrorOnCreateDirectory = "Directory name is empty."
+    let sut = makeSUT(fileManager: errorFileManager)
+    let outputDirectory = NSTemporaryDirectory()
+    let directoryName = ""
+    
+    XCTAssertThrowsError(try sut.createDirectory(named: directoryName, in: outputDirectory)) { error in
+      XCTAssertEqual((error as? DirectoryOperationError)?.errorDescription, DirectoryOperationError.folderCreationFailed("Directory name is empty.").errorDescription)
     }
   }
   
@@ -47,7 +59,7 @@ final class DirectoryOperatorTests: XCTestCase {
   
   func test_removeFiles_throwsError_onRemoveItem() throws {
     let errorFileManager = MockFileManager()
-    errorFileManager.shouldThrowErrorOnRemoveItem = true
+    errorFileManager.shouldThrowErrorOnRemoveItem = "Remove_failed"
     let sut = makeSUT(fileManager: errorFileManager)
     let outputDirectory = NSTemporaryDirectory()
     let directoryName = "TestDirectory"
@@ -64,7 +76,7 @@ final class DirectoryOperatorTests: XCTestCase {
     // Test the error case
     XCTAssertThrowsError(try sut.removeFiles(withPrefix: .packageName, in: createdDirectoryURL)) { error in
       XCTAssertEqual((error as? DirectoryOperationError)?.localizedDescription,
-                     DirectoryOperationError.removeItemFailed.localizedDescription)
+                     DirectoryOperationError.removeItemFailed("Remove_failed").localizedDescription)
     }
   }
 }

--- a/Tests/LinguaTests/Infrastructure/DirectoryOperations/DirectoryOperatorTests.swift
+++ b/Tests/LinguaTests/Infrastructure/DirectoryOperations/DirectoryOperatorTests.swift
@@ -13,7 +13,7 @@ final class DirectoryOperatorTests: XCTestCase {
   
   func test_createDirectory_throwsError_onFailure() {
     let errorFileManager = MockFileManager()
-    errorFileManager.shouldThrowErrorOnCreateDirectory = "Create_failed"
+    errorFileManager.onCreateDirectoryError = "Create_failed"
     let sut = makeSUT(fileManager: errorFileManager)
     let outputDirectory = NSTemporaryDirectory()
     let directoryName = "TestDirectory"
@@ -25,7 +25,7 @@ final class DirectoryOperatorTests: XCTestCase {
   
   func test_createDirectory_throwsError_onEmptyDirectory() {
     let errorFileManager = MockFileManager()
-    errorFileManager.shouldThrowErrorOnCreateDirectory = "Directory name is empty."
+    errorFileManager.onCreateDirectoryError = "Directory name is empty."
     let sut = makeSUT(fileManager: errorFileManager)
     let outputDirectory = NSTemporaryDirectory()
     let directoryName = ""
@@ -59,7 +59,7 @@ final class DirectoryOperatorTests: XCTestCase {
   
   func test_removeFiles_throwsError_onRemoveItem() throws {
     let errorFileManager = MockFileManager()
-    errorFileManager.shouldThrowErrorOnRemoveItem = "Remove_failed"
+    errorFileManager.onRemoveItemError = "Remove_failed"
     let sut = makeSUT(fileManager: errorFileManager)
     let outputDirectory = NSTemporaryDirectory()
     let directoryName = "TestDirectory"

--- a/Tests/LinguaTests/Infrastructure/DirectoryOperations/Mock/MockFileManager.swift
+++ b/Tests/LinguaTests/Infrastructure/DirectoryOperations/Mock/MockFileManager.swift
@@ -3,8 +3,8 @@ import Foundation
 
 final class MockFileManager: FileManager {
   let files: [String]
-  var shouldThrowErrorOnRemoveItem = false
-  var shouldThrowErrorOnCreateDirectory = false
+  var shouldThrowErrorOnRemoveItem: String?
+  var shouldThrowErrorOnCreateDirectory: String?
   
   init(files: [String] = []) {
     self.files = files
@@ -17,16 +17,16 @@ final class MockFileManager: FileManager {
   override func createDirectory(at url: URL,
                                 withIntermediateDirectories createIntermediates: Bool,
                                 attributes: [FileAttributeKey : Any]? = nil) throws {
-    if shouldThrowErrorOnCreateDirectory {
-      throw DirectoryOperationError.folderCreationFailed
+    if let shouldThrowErrorOnCreateDirectory {
+      throw DirectoryOperationError.folderCreationFailed(shouldThrowErrorOnCreateDirectory)
     } else {
       try super.createDirectory(at: url, withIntermediateDirectories: createIntermediates, attributes: attributes)
     }
   }
   
   override func removeItem(at URL: URL) throws {
-    if shouldThrowErrorOnRemoveItem {
-      throw NSError(domain: NSCocoaErrorDomain, code: NSFileWriteUnknownError, userInfo: nil)
+    if let shouldThrowErrorOnRemoveItem {
+      throw DirectoryOperationError.removeItemFailed(shouldThrowErrorOnRemoveItem)
     } else {
       try super.removeItem(at: URL)
     }

--- a/Tests/LinguaTests/Infrastructure/DirectoryOperations/Mock/MockFileManager.swift
+++ b/Tests/LinguaTests/Infrastructure/DirectoryOperations/Mock/MockFileManager.swift
@@ -3,8 +3,8 @@ import Foundation
 
 final class MockFileManager: FileManager {
   let files: [String]
-  var shouldThrowErrorOnRemoveItem: String?
-  var shouldThrowErrorOnCreateDirectory: String?
+  var onRemoveItemError: String?
+  var onCreateDirectoryError: String?
   
   init(files: [String] = []) {
     self.files = files
@@ -17,16 +17,16 @@ final class MockFileManager: FileManager {
   override func createDirectory(at url: URL,
                                 withIntermediateDirectories createIntermediates: Bool,
                                 attributes: [FileAttributeKey : Any]? = nil) throws {
-    if let shouldThrowErrorOnCreateDirectory {
-      throw DirectoryOperationError.folderCreationFailed(shouldThrowErrorOnCreateDirectory)
+    if let onCreateDirectoryError {
+      throw DirectoryOperationError.folderCreationFailed(onCreateDirectoryError)
     } else {
       try super.createDirectory(at: url, withIntermediateDirectories: createIntermediates, attributes: attributes)
     }
   }
   
   override func removeItem(at URL: URL) throws {
-    if let shouldThrowErrorOnRemoveItem {
-      throw DirectoryOperationError.removeItemFailed(shouldThrowErrorOnRemoveItem)
+    if let onRemoveItemError {
+      throw DirectoryOperationError.removeItemFailed(onRemoveItemError)
     } else {
       try super.removeItem(at: URL)
     }

--- a/Tests/LinguaTests/Infrastructure/LocalizationGenerator/Generator/ConfigInitialFileGeneratorTests.swift
+++ b/Tests/LinguaTests/Infrastructure/LocalizationGenerator/Generator/ConfigInitialFileGeneratorTests.swift
@@ -16,7 +16,7 @@ final class ConfigInitialFileGeneratorTests: XCTestCase {
   }
   
   func test_generate_throwsErrorOnFailure() {
-    let (sut, _) = makeSUT(shouldFail: true)
+    let (sut, _) = makeSUT(shouldFail: "error")
     
     XCTAssertThrowsError(try sut.generate())
   }
@@ -38,7 +38,7 @@ private extension ConfigInitialFileGeneratorTests {
     let fileName: String
   }
   
-  func makeSUT(shouldFail: Bool = false, encoder: JSONEncoding? = nil) -> (sut: ConfigInitialFileGenerator, actors: Actors) {
+  func makeSUT(shouldFail: String? = .none, encoder: JSONEncoding? = nil) -> (sut: ConfigInitialFileGenerator, actors: Actors) {
     let contentFilesCreator = MockContentFilesCreator()
     contentFilesCreator.shouldThrowError = shouldFail
     let config = Config.createTemplateConfig()

--- a/Tests/LinguaTests/Infrastructure/LocalizationGenerator/Generator/ConfigInitialFileGeneratorTests.swift
+++ b/Tests/LinguaTests/Infrastructure/LocalizationGenerator/Generator/ConfigInitialFileGeneratorTests.swift
@@ -40,7 +40,7 @@ private extension ConfigInitialFileGeneratorTests {
   
   func makeSUT(shouldFail: String? = .none, encoder: JSONEncoding? = nil) -> (sut: ConfigInitialFileGenerator, actors: Actors) {
     let contentFilesCreator = MockContentFilesCreator()
-    contentFilesCreator.shouldThrowError = shouldFail
+    contentFilesCreator.errorMessage = shouldFail
     let config = Config.createTemplateConfig()
     let transformer = ConfigTransformer()
     let fileName = "config.json"

--- a/Tests/LinguaTests/Infrastructure/LocalizationGenerator/Generator/LocalizedPlatformFilesGeneratorTests.swift
+++ b/Tests/LinguaTests/Infrastructure/LocalizationGenerator/Generator/LocalizedPlatformFilesGeneratorTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class LocalizedPlatformFilesGeneratorTests: XCTestCase {
   func test_createPlatformFiles_createsFilesSuccessfully() throws {
-    let (contentGenerator, filesCreator) = makeContentGeneratorAndCreator(shouldFilesCreatorThrowError: .none)
+    let (contentGenerator, filesCreator) = makeContentGeneratorAndCreator(filesCreatorThrownErrorMessage: .none)
     let fileExtension = "txt"
     let fileNameGenerator = MockPlatformFilesNameGenerator(fileExtension: fileExtension)
     let sut = makeSUT(contentGenerator: contentGenerator, filesCreator: filesCreator, fileNameGenerator: fileNameGenerator)
@@ -18,7 +18,7 @@ final class LocalizedPlatformFilesGeneratorTests: XCTestCase {
   }
   
   func test_createPlatformFiles_throwsErrorAndLogsMessage_onCreateFilesFailure() {
-    let (contentGenerator, filesCreator) = makeContentGeneratorAndCreator(shouldFilesCreatorThrowError: "Error_message")
+    let (contentGenerator, filesCreator) = makeContentGeneratorAndCreator(filesCreatorThrownErrorMessage: "Error_message")
     let sut = makeSUT(contentGenerator: contentGenerator, filesCreator: filesCreator)
     let entries: [LocalizationEntry] = [.create(plural: true)]
     let outputFolder = URL(fileURLWithPath: NSTemporaryDirectory())
@@ -32,12 +32,12 @@ final class LocalizedPlatformFilesGeneratorTests: XCTestCase {
   }
   
   func makeContentGeneratorAndCreator(
-    shouldFilesCreatorThrowError: String?
+    filesCreatorThrownErrorMessage: String?
   ) -> (contentGenerator: MockLocalizedContentGenerator, filesCreator: MockContentFilesCreator) {
     let contentGenerator = MockLocalizedContentGenerator()
     contentGenerator.content = ("stringsContent", "stringsDictContent")
     let filesCreator = MockContentFilesCreator()
-    filesCreator.shouldThrowError = shouldFilesCreatorThrowError
+    filesCreator.errorMessage = filesCreatorThrownErrorMessage
     return (contentGenerator, filesCreator)
   }
 }

--- a/Tests/LinguaTests/Infrastructure/LocalizationGenerator/Generator/LocalizedPlatformFilesGeneratorTests.swift
+++ b/Tests/LinguaTests/Infrastructure/LocalizationGenerator/Generator/LocalizedPlatformFilesGeneratorTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class LocalizedPlatformFilesGeneratorTests: XCTestCase {
   func test_createPlatformFiles_createsFilesSuccessfully() throws {
-    let (contentGenerator, filesCreator) = makeContentGeneratorAndCreator()
+    let (contentGenerator, filesCreator) = makeContentGeneratorAndCreator(shouldFilesCreatorThrowError: .none)
     let fileExtension = "txt"
     let fileNameGenerator = MockPlatformFilesNameGenerator(fileExtension: fileExtension)
     let sut = makeSUT(contentGenerator: contentGenerator, filesCreator: filesCreator, fileNameGenerator: fileNameGenerator)
@@ -18,7 +18,7 @@ final class LocalizedPlatformFilesGeneratorTests: XCTestCase {
   }
   
   func test_createPlatformFiles_throwsErrorAndLogsMessage_onCreateFilesFailure() {
-    let (contentGenerator, filesCreator) = makeContentGeneratorAndCreator(shouldFilesCreatorThrowError: true)
+    let (contentGenerator, filesCreator) = makeContentGeneratorAndCreator(shouldFilesCreatorThrowError: "Error_message")
     let sut = makeSUT(contentGenerator: contentGenerator, filesCreator: filesCreator)
     let entries: [LocalizationEntry] = [.create(plural: true)]
     let outputFolder = URL(fileURLWithPath: NSTemporaryDirectory())
@@ -27,12 +27,12 @@ final class LocalizedPlatformFilesGeneratorTests: XCTestCase {
                                                      sectionName: "SectionName",
                                                      outputFolder: outputFolder,
                                                      language: "en")) { error in
-      XCTAssertEqual(error as? DirectoryOperationError, DirectoryOperationError.folderCreationFailed)
+      XCTAssertEqual(error as? DirectoryOperationError, DirectoryOperationError.folderCreationFailed("Error_message"))
     }
   }
   
   func makeContentGeneratorAndCreator(
-    shouldFilesCreatorThrowError: Bool = false
+    shouldFilesCreatorThrowError: String?
   ) -> (contentGenerator: MockLocalizedContentGenerator, filesCreator: MockContentFilesCreator) {
     let contentGenerator = MockLocalizedContentGenerator()
     contentGenerator.content = ("stringsContent", "stringsDictContent")

--- a/Tests/LinguaTests/Infrastructure/LocalizationGenerator/Generator/Mock/MockContentFilesCreator.swift
+++ b/Tests/LinguaTests/Infrastructure/LocalizationGenerator/Generator/Mock/MockContentFilesCreator.swift
@@ -3,15 +3,15 @@ import Foundation
 
 class MockContentFilesCreator: ContentFileCreatable {
   var writtenContent: [String: String] = [:]
-  var shouldThrowError: String?
+  var errorMessage: String?
   
   func createFiles(with content: String, fileName: String, outputFolder: URL) throws {
     try createFilesInCurrentDirectory(with: content, fileName: fileName)
   }
   
   func createFilesInCurrentDirectory(with content: String, fileName: String) throws {
-    if let shouldThrowError {
-      throw DirectoryOperationError.folderCreationFailed(shouldThrowError)
+    if let errorMessage {
+      throw DirectoryOperationError.folderCreationFailed(errorMessage)
     }
     writtenContent[fileName] = content
   }

--- a/Tests/LinguaTests/Infrastructure/LocalizationGenerator/Generator/Mock/MockContentFilesCreator.swift
+++ b/Tests/LinguaTests/Infrastructure/LocalizationGenerator/Generator/Mock/MockContentFilesCreator.swift
@@ -3,15 +3,15 @@ import Foundation
 
 class MockContentFilesCreator: ContentFileCreatable {
   var writtenContent: [String: String] = [:]
-  var shouldThrowError = false
+  var shouldThrowError: String?
   
   func createFiles(with content: String, fileName: String, outputFolder: URL) throws {
     try createFilesInCurrentDirectory(with: content, fileName: fileName)
   }
   
   func createFilesInCurrentDirectory(with content: String, fileName: String) throws {
-    if shouldThrowError {
-      throw DirectoryOperationError.folderCreationFailed
+    if let shouldThrowError {
+      throw DirectoryOperationError.folderCreationFailed(shouldThrowError)
     }
     writtenContent[fileName] = content
   }

--- a/Tests/LinguaTests/Infrastructure/SwiftLocalizeGenerator/Generator/SwiftLocalizedCodeFileGeneratorTests.swift
+++ b/Tests/LinguaTests/Infrastructure/SwiftLocalizeGenerator/Generator/SwiftLocalizedCodeFileGeneratorTests.swift
@@ -18,14 +18,14 @@ final class SwiftLocalizedCodeFileGeneratorTests: XCTestCase {
   func test_generate_printsErrorOnCreateFilesFailure() {
     let mockLogger = MockLogger()
     let mockContentFilesCreator = MockContentFilesCreator()
-    mockContentFilesCreator.shouldThrowError = true
+    mockContentFilesCreator.shouldThrowError = "Error_message"
     let sut = makeSUT(mockLogger: mockLogger,
                       mockContentFilesCreator: mockContentFilesCreator)
     
     sut.generate(from: "inputPath", outputPath: "outputPath")
     
     XCTAssertEqual(mockLogger.messages,
-                   [.message(message: DirectoryOperationError.folderCreationFailed.errorDescription ?? "", level: .error)])
+                   [.message(message: DirectoryOperationError.folderCreationFailed("Error_message").localizedDescription, level: .error)])
   }
 }
 

--- a/Tests/LinguaTests/Infrastructure/SwiftLocalizeGenerator/Generator/SwiftLocalizedCodeFileGeneratorTests.swift
+++ b/Tests/LinguaTests/Infrastructure/SwiftLocalizeGenerator/Generator/SwiftLocalizedCodeFileGeneratorTests.swift
@@ -18,7 +18,7 @@ final class SwiftLocalizedCodeFileGeneratorTests: XCTestCase {
   func test_generate_printsErrorOnCreateFilesFailure() {
     let mockLogger = MockLogger()
     let mockContentFilesCreator = MockContentFilesCreator()
-    mockContentFilesCreator.shouldThrowError = "Error_message"
+    mockContentFilesCreator.errorMessage = "Error_message"
     let sut = makeSUT(mockLogger: mockLogger,
                       mockContentFilesCreator: mockContentFilesCreator)
     


### PR DESCRIPTION
Found an issue when directory folders are named with space like `Untitled Folder`, than the localization won't work.
- The fix removes percentage encodings.
- Add more detailed errors if happens again
- Improve TextField